### PR TITLE
Adds change method, disables turbolinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ last: false
 display_max: 8
 # render nothing if there is only 1 page:
 ignore_single_page: true
+# disable turbolinks:
+no_turbolink: false
 ```
 
 ## Contributing

--- a/spec/javascripts/jquery-bootstrap-pagination_spec.coffee
+++ b/spec/javascripts/jquery-bootstrap-pagination_spec.coffee
@@ -78,6 +78,12 @@ describe "pagination", ->
       expect(links[2]).toEqual("<li><a href='#' data-page='2'>2</a></li>")
       expect(links[3]).toEqual("<li><a href='#' data-page='3'>3</a></li>")
       
+    it "disables turbolinks (if requested)", ->
+      @view.settings.prev = "prev"
+      @view.settings.current_page = 2
+      @view.settings.no_turbolink = true
+      links = @view.buildLinks()
+      expect(links[0]).toEqual("<li><a href='#' data-page='1' data-no-turbolink='1'>prev</a></li>")
 
   describe "render", ->
     

--- a/src/jquery-bootstrap-pagination.coffee
+++ b/src/jquery-bootstrap-pagination.coffee
@@ -42,6 +42,8 @@
         display_max: 8
         # render nothing if there is only 1 page:
         ignore_single_page: true
+        # disable turbolinks
+        no_turbolink: false
 
       # merge defaults with passed in options:
       @settings = $.extend(defaults, options)
@@ -83,8 +85,16 @@
       return links
 
     # build the `li` element for the link:
-    buildLi: (page, text = page)=>
-      "<li><a href='#' data-page='#{page}'>#{text}</a></li>"
+    buildLi: (page, text = page) =>
+      "<li>#{@buildLink(page, text)}</li>"
+
+    # build the link element
+    buildLink: (page, text = page) =>
+      if @settings.no_turbolink
+        data_attr = " data-no-turbolink='1'"
+      else
+        data_attr = ""
+      "<a href='#' data-page='#{page}'#{data_attr}>#{text}</a>"
 
     # returns an array of all of the 'pages' in the pagination:
     pages: =>

--- a/vendor/assets/javascripts/jquery-bootstrap-pagination.js
+++ b/vendor/assets/javascripts/jquery-bootstrap-pagination.js
@@ -34,6 +34,7 @@
         this.isValidPage = __bind(this.isValidPage, this);
         this.render = __bind(this.render, this);
         this.pages = __bind(this.pages, this);
+        this.buildLink = __bind(this.buildLink, this);
         this.buildLi = __bind(this.buildLi, this);
         this.buildLinks = __bind(this.buildLinks, this);
         defaults = {
@@ -44,7 +45,8 @@
           first: false,
           last: false,
           display_max: 8,
-          ignore_single_page: true
+          ignore_single_page: true,
+          no_turbolink: false
         };
         this.settings = $.extend(defaults, options);
         if ($(document).on) {
@@ -84,7 +86,21 @@
         if (text == null) {
           text = page;
         }
-        return "<li><a href='#' data-page='" + page + "'>" + text + "</a></li>";
+        return "<li>" + (this.buildLink(page, text)) + "</li>";
+      };
+
+      PaginationView.prototype.buildLink = function(page, text) {
+        var data_attr;
+
+        if (text == null) {
+          text = page;
+        }
+        if (this.settings.no_turbolink) {
+          data_attr = " data-no-turbolink='1'";
+        } else {
+          data_attr = "";
+        }
+        return "<a href='#' data-page='" + page + "'" + data_attr + ">" + text + "</a>";
       };
 
       PaginationView.prototype.pages = function() {


### PR DESCRIPTION
Disabling turbolinks prevents errors in the console when turbolinks (default in rails4) is used. If you don't feel it's appropriate to add that, I can remove it.

More info here: https://github.com/rails/turbolinks/

The change method allows a pager to have it's page changed via JS. This is useful when you have multiple pagers on a page and want to keep them in sync. The callback, if supplied, is not called when change is invoked.
