### PR TITLE
Add prevent default code for link click event…

### DIFF
--- a/src/jquery-bootstrap-pagination.coffee
+++ b/src/jquery-bootstrap-pagination.coffee
@@ -180,6 +180,7 @@
 
     # called when a link is clicked in the pagination list:
     clicked: (event) =>
+      event.preventDefault()
       page = parseInt($(event.target).attr("data-page"))
       return unless @isValidPage(page)
       # if there is a callback registered, then call it


### PR DESCRIPTION
Add prevent default code for link click event to avoid jump to '#' route in one page application.